### PR TITLE
Always leave election when stopping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ unit_test:
 ### Dev
 
 .PHONY: run
-run: create_cluster install_agent_example
+run: check_dev_dependencies create_cluster install_agent_example
 
 .PHONY: create_cluster
 create_cluster: ## run a local k3d cluster
@@ -62,6 +62,14 @@ run_agent_local: dist
 
 dist:
 	mkdir -p dist
+
+.PHONY: check_dev_dependencies
+check_dev_dependencies: ## Checks that all the necesary depencencies for the dev env are present
+	@helm version >/dev/null 2>&1 || (echo "ERROR: helm is required."; exit 1)
+	@k3d version >/dev/null 2>&1 || (echo "ERROR: k3d is required."; exit 1)
+	@kubectl version --client >/dev/null 2>&1 || (echo "ERROR: kubectl is required."; exit 1)
+	@ko version >/dev/null 2>&1 || (echo "ERROR: google/ko is required."; exit 1)
+	@grep -Fq "prometheus-elector-registry.localhost" /etc/hosts || (echo "ERROR: please add the following line `prometheus-elector-registry.localhost 127.0.0.1` to your /etc/hosts file"; exit 1)
 
 ### CI
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,13 @@ unit_test:
 ### Dev
 
 .PHONY: run
-run: check_dev_dependencies create_cluster install_agent_example
+run: run_agent_example
+
+.PHONY: run_agent_example
+run_agent_example: check_dev_dependencies create_cluster install_agent_example
+
+.PHONY: run_proxy_example
+run_proxy_example: check_dev_dependencies create_cluster install_proxy_example
 
 .PHONY: create_cluster
 create_cluster: ## run a local k3d cluster
@@ -36,8 +42,8 @@ install_agent_example: install_storage
 		-f ./example/k8s/agent-values.yaml \
 		prometheus-elector-dev ./helm | KO_DOCKER_REPO=prometheus-elector-registry.localhost:5000 ko apply -B -t dev -f -
 
-.PHONY: install_ha_example
-install_ha_example:
+.PHONY: install_proxy_example
+install_proxy_example:
 	helm template \
 		--set elector.image.devRef=ko://github.com/jlevesy/prometheus-elector/cmd \
 		--set prometheus.image.repository=jlevesy/prometheus \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ You can find the necessary configuration for this use case in the [example direc
 
 #### Running an Example of this Setup
 
-You need [ko](https://github.com/ko-build/ko), `kubectl` and [k3d](https://github.com/k3d-io/k3d) and docker installed, from there run `make create_cluster install_agent_example`.
+You need [ko](https://github.com/ko-build/ko), `kubectl`, [k3d](https://github.com/k3d-io/k3d), `docker` and `helm` installed. You also need to make sure that `prometheus-elector-registry.localhost` resolves to `127.0.0.1` by adding an entry in your `/etc/hosts`.
+
+You can then run `make run_agent_example`.
 
 This command:
 
@@ -51,7 +53,10 @@ You can find the necessary configuration for this use case in the [example direc
 
 #### Running an Example of this setup
 
-You need [ko](https://github.com/ko-build/ko), `kubectl` and [k3d](https://github.com/k3d-io/k3d) and docker installed, from there run `make create_cluster install_ha_example`.
+
+You need [ko](https://github.com/ko-build/ko), `kubectl`, [k3d](https://github.com/k3d-io/k3d), `docker` and `helm` installed. You also need to make sure that `prometheus-elector-registry.localhost` resolves to `127.0.0.1` by adding an entry in your `/etc/hosts`.
+
+Then you can run `make run_proxy_example`.
 
 This command:
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -178,8 +178,8 @@ func (c *cliConfig) setupFlags() {
 
 	flag.StringVar(&c.leaseName, "lease-name", "", "Name of lease resource")
 	flag.StringVar(&c.leaseNamespace, "lease-namespace", "", "Name of lease resource namespace")
-	flag.DurationVar(&c.leaseDuration, "lease-duration", 15*time.Second, "Duration of a lease, client wait the full duration of a lease before trying to take it over")
-	flag.DurationVar(&c.leaseRenewDeadline, "lease-renew-deadline", 10*time.Second, "Maximum duration spent trying to renew the lease")
+	flag.DurationVar(&c.leaseDuration, "lease-duration", 10*time.Second, "Duration of a lease, client wait the full duration of a lease before trying to take it over")
+	flag.DurationVar(&c.leaseRenewDeadline, "lease-renew-deadline", 8*time.Second, "Maximum duration spent trying to renew the lease")
 	flag.DurationVar(&c.leaseRetryPeriod, "lease-retry-period", 2*time.Second, "Delay between two attempts of taking/renewing the lease")
 
 	flag.StringVar(&c.kubeConfigPath, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -134,14 +134,18 @@ func main() {
 		klog.Fatal("Can't setup election", err)
 	}
 
-	// Always stop the election.
+	// Always leave the election.
 	defer func() {
 		stopCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
+		klog.Info("Graceful shutdown, leaving the election")
+
 		if err := elector.Stop(stopCtx); err != nil && errors.Is(err, election.ErrNotRunning) {
-			klog.ErrorS(err, "unable to stop the elector")
+			klog.ErrorS(err, "Unable to leave the election")
 		}
+
+		klog.Info("Graceful shutdown, left the election")
 	}()
 
 	reconciller.SetLeaderChecker(elector.Status())
@@ -251,5 +255,5 @@ func main() {
 		klog.Fatal("Error while running prometheus-elector, reason: ", err)
 	}
 
-	klog.Info("prometheus-elector exited successfully")
+	klog.Info("prometheus-elector is stopping")
 }

--- a/notifier/retry.go
+++ b/notifier/retry.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -27,6 +28,10 @@ func (r *retryNotifier) Notify(ctx context.Context) error {
 
 	for j := r.maxAttempts; j > 0; j-- {
 		if err = r.next.Notify(ctx); err == nil {
+			return nil
+		}
+
+		if errors.Is(err, context.Canceled) {
 			return nil
 		}
 

--- a/readiness/http.go
+++ b/readiness/http.go
@@ -65,7 +65,7 @@ func (w *httpWaiter) checkReadiness(ctx context.Context) (bool, error) {
 	}
 
 	if rsp.StatusCode != http.StatusOK {
-		klog.Error("Prometheus isn't ready yet", "status", rsp.StatusCode)
+		klog.InfoS("Prometheus isn't ready yet", "status", rsp.StatusCode)
 		return false, nil
 	}
 


### PR DESCRIPTION
### What Does This PR do?

So a couple of things were wrong in how the termination was happening. This PR adresses the following issues.

- The context wasn't canceled on SIGTERM, which means prometheus-elector was never properly stopped and leaving the election
- I used `Fatal`, which is a mistake because it does not honor the scheduled `defer` introducing a risk of not leaving the election. Never use `Fatal` kids.
- The notifier was retyring even if the given context is canceled.
- Better logs
- Couple of DX improvements (better makefile targets, preflight checks for tooling, better requirements) 
- Lowers the default lease period to 10s

This leads to much better failover time on graceful shutdowns

### How to Test This PR?

```
make run # then kill pods and look for the logs
```

### Good PR Checklist

- [x] Addresses one issue
- [x] Adds/Updates unit tests
- [x] Adds/Updates the documentation
- [ ] Opened against the right branch
- [x] Correctly Labeled