### PR TITLE
fix(election): retry participating if the lease is improperly lost

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,8 @@ jobs:
           check-latest: true
           cache: true
       - name: Run Tests
-        run: make test
+        run: |
+          TIMEOUT=1m make test
 
   lint:
     name: Lint Code

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 K3S_VERSION = v1.25.0-k3s1
 RELEASE_TAG ?= dev
+TIMEOUT ?= 5s
 
 ### Tests
 
@@ -8,7 +9,7 @@ test: unit_test
 
 .PHONY: unit_test
 unit_test:
-	go test -v -cover -race -timeout=5s ./...
+	go test -v -cover -race -timeout=$(TIMEOUT) ./...
 
 ### Dev
 

--- a/election/elector_test.go
+++ b/election/elector_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jlevesy/prometheus-elector/election"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/leaderelection"
 )
@@ -69,3 +70,76 @@ func TestElector(t *testing.T) {
 		assert.Equal(t, "", elector.Status().GetLeader())
 	}
 }
+
+func TestElector_ContinuesParticipatingIfItLoosesTheLease(t *testing.T) {
+	var (
+		ctx        = context.Background()
+		kubeClient = kubefake.NewSimpleClientset()
+		config     = election.Config{
+			LeaseName:      "test",
+			LeaseNamespace: "test",
+			MemberID:       "foo",
+			LeaseDuration:  time.Second,
+			RenewDeadline:  500 * time.Millisecond,
+			RetryPeriod:    200 * time.Millisecond,
+		}
+		startedLeading = make(chan struct{}, 1)
+		stoppedLeading = make(chan struct{}, 1)
+		leasesClient   = kubeClient.CoordinationV1().Leases(config.LeaseNamespace)
+	)
+
+	elector, err := election.New(
+		config,
+		kubeClient,
+		leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				startedLeading <- struct{}{}
+			},
+			OnStoppedLeading: func() {
+				stoppedLeading <- struct{}{}
+			},
+		},
+		nil, // nil metrics registry. We don't really care about them in this test.
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		err = elector.Stop(ctx)
+		require.NoError(t, err)
+	}()
+
+	err = elector.Start(ctx)
+	require.NoError(t, err)
+
+	<-startedLeading
+	assert.True(t, elector.Status().IsLeader())
+	assert.Equal(t, "foo", elector.Status().GetLeader())
+
+	// Let's hijack the lease by hand.
+	lease, err := leasesClient.Get(ctx, config.LeaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	leaseCopy := lease.DeepCopy()
+	leaseCopy.Spec.HolderIdentity = strPtr("bozo")
+
+	_, err = leasesClient.Update(ctx, leaseCopy, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// This should make our current elector lose the leadership.
+	<-stoppedLeading
+
+	// Let's now reset things back to normal.
+	lease, err = leasesClient.Get(ctx, config.LeaseName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	leaseCopy = lease.DeepCopy()
+	leaseCopy.Spec.HolderIdentity = strPtr(config.MemberID)
+
+	_, err = leasesClient.Update(ctx, leaseCopy, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// And we're back leading again!
+	<-startedLeading
+}
+
+func strPtr(s string) *string { return &s }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jlevesy/prometheus-elector
 
-go 1.20
+go 1.21
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -22,9 +22,11 @@ github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En
 github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -39,6 +41,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
@@ -51,6 +54,7 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -67,7 +71,9 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
+github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
+github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -81,6 +87,7 @@ github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
### What Does This PR do?

This PR fixes an issue where a prometheus-elector instance could stop participating into the election indefinitely if it loses (ie: without releasing it explicitly) the election lease. 

In that case, the `LeaderElector.Run` method (see [here](https://github.com/kubernetes/client-go/blob/master/tools/leaderelection/leaderelection.go#L202)) exits, this is actually documented 🤦 .

But the previous implementation didn't account for that and it was leading to the actual member not taking part into the election anymore.

This PR fixes this issue by checking if the given `runCtx` is done or not after `Run` exits. 
- If the context is not done, it means that we're still supposed to participate to the election, so we're recalling `elector.Run` to join back the election again.
- If the context is done, then it means that we're in a proper termination. So it signals its termination and exits.

### How to Test This PR?

```
# Run the agent example
make run_agent_example

# In another terminal monitor the logs
stern .

# In a third terminal, set the `spec.holderIdentity` field to  ` prometheus-elector-dev-1`
k edit lease prometheus-elector-lease

# You should see elector-1 take the ownership, and elector-0 drop it
# after a while and then start grabbing again the lease.
# Then do the opposite operation, and you'll see the roles reversing. On the current main, prometheus-elector-0 would have been dead in the water.
```

### Good PR Checklist

- [x] Addresses one issue
- [x] Adds/Updates unit tests
- [ ] Adds/Updates the documentation
- [x] Opened against the right branch
- [x] Correctly Labeled

### Additional Notes

<!-- Add any information here that could be helpful to the mainteners for understanding your contrition -->
