### PR TITLE
chore(config): add a log line when writing leader configuration

### DIFF
--- a/config/reconcile.go
+++ b/config/reconcile.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/imdario/mergo"
 	"github.com/jlevesy/prometheus-elector/election"
+	"k8s.io/klog/v2"
 )
 
 type Reconciler struct {
@@ -34,6 +35,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	targetCfg := cfg.Follower
 
 	if cfg.Leader != nil && r.leaderChecker != nil && r.leaderChecker.IsLeader() {
+		klog.Info("Writing leader configuration")
 		if err := mergo.Merge(
 			&targetCfg,
 			cfg.Leader,


### PR DESCRIPTION
### What Does This PR do?

Still investigating a bug where prometheus-elector writes the leader configuration when it improperly looses the leadership. 

This PR adds a log line that will clearly highlight a potential race.