### PR TITLE
fix(*): rely only on callbacks to decide which config to write

### DIFF
--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -60,7 +60,7 @@ func TestFileWatcher(t *testing.T) {
 	err := simulateConfigmapWrite(dir, fileName, []byte(defaultConfig))
 	require.NoError(t, err)
 
-	watcher, err := watcher.New(dir, reconciler, notifierFunc(notifier))
+	watcher, err := watcher.New(dir, reconciler, notifierFunc(notifier), leaderCheckerFunc(func() bool { return false }))
 	require.NoError(t, err)
 
 	defer watcher.Close()
@@ -113,3 +113,7 @@ type notifierFunc func() error
 func (n notifierFunc) Notify(context.Context) error {
 	return n()
 }
+
+type leaderCheckerFunc func() bool
+
+func (l leaderCheckerFunc) IsLeader() bool { return l() }


### PR DESCRIPTION
### What Does This PR do?

This PR fixes an issue where prometheus-elector, when improperly loosing the leadership (Kube API timeout), continues writing the leader configuration even if has lost the leadership.

It turns out that using `IsLeader())` on the status object isn't reliable after the main election loop has  exited. Which can happen due to #60. 

This PR addresses this problem by only relying on which callback is called by the election object. 